### PR TITLE
Add steering committee as code owners of all files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Make the steering committee code owners of all files
+* @OpenShipping/steering-committee
+
+


### PR DESCRIPTION
- Adds a CODEOWNERS file that will require 1 PR Approval from a member of the steering committee on any file in the repository